### PR TITLE
Add order book tracking and quality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@
 
   * `connect()` — открывает N сокетов, автосплит по 30 стримов ([mexcdevelop.github.io][1], [mexc.com][2]).
   * `subscribe(pair)` / `unsubscribe(pair)`
+  * авто-отписка при `spread > 1.5 %` или `volume_5m < $20k`
   * `yield ticks` → `Tick(kline: dict, depth: dict)`
+  * `get_best(pair)` — лучшая цена bid/ask
+  * `get_cum_depth(pair)` — суммарный объём внутри ±10 bps
 
 #### 6.2 Feature Engine (`features.py`)
 


### PR DESCRIPTION
## Summary
- maintain L10 order book per pair from depth streams
- expose helpers `get_best()` and `get_cum_depth()`
- drop pairs when spread >1.5% or 5‑min volume < $20k
- document new MexcWSClient API

## Testing
- `python -m py_compile collector.py`

------
https://chatgpt.com/codex/tasks/task_e_684ee733f0a08321a05721692fee160c