### PR TITLE
Add threshold-based filtering and config reload

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,27 @@
+import yaml
+from typing import Dict, Any
+from pathlib import Path
+
+_CONFIG_PATH = Path(__file__).with_name('config.yaml')
+_config: Dict[str, Any] = {}
+
+
+def load_config(path: Path | str | None = None) -> Dict[str, Any]:
+    """Load configuration from YAML file."""
+    global _config
+    cfg_path = Path(path) if path else _CONFIG_PATH
+    with cfg_path.open('r') as f:
+        _config = yaml.safe_load(f)
+    return _config
+
+
+def get_thresholds() -> Dict[str, float]:
+    """Return scanner metric thresholds."""
+    if not _config:
+        load_config()
+    return _config.get('scanner', {}).get('metrics', {})
+
+
+def reload_config(path: Path | str | None = None) -> Dict[str, Any]:
+    """Reload configuration at runtime."""
+    return load_config(path)

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,17 @@
+mexc:
+  ws_url: wss://contract.mexc.com/ws
+  rest_url: https://api.mexc.com
+  api_key: ${MEXC_KEY}
+  api_secret: ${MEXC_SECRET}
+scanner:
+  stake_usdt: 100
+  prob_threshold: 0.60
+  metrics:
+    vsr: 5
+    pm: 0.02
+    obi: 0.25
+    spread: 0.015
+    listing_age_min: 900
+telegram:
+  token: ${TG_TOKEN}
+  allowed_ids: [123456789]

--- a/model.json
+++ b/model.json
@@ -1,0 +1,1 @@
+{"intercept": -1.0, "coefficients": {"vsr": 0.4, "pm": 0.35, "obi": 0.25}}

--- a/model.py
+++ b/model.py
@@ -1,0 +1,28 @@
+import json
+import math
+from pathlib import Path
+from typing import Dict
+
+from features import FeatureVector
+
+_MODEL_PATH = Path(__file__).with_name('model.json')
+
+
+class LogisticModel:
+    def __init__(self, intercept: float, coefficients: Dict[str, float]) -> None:
+        self.intercept = intercept
+        self.coef = coefficients
+
+    def predict_proba(self, fv: FeatureVector) -> float:
+        x = self.intercept
+        x += fv.vsr * self.coef.get('vsr', 0.0)
+        x += fv.pm * self.coef.get('pm', 0.0)
+        x += fv.obi * self.coef.get('obi', 0.0)
+        return 1.0 / (1.0 + math.exp(-x))
+
+
+def load_model(path: Path | str | None = None) -> LogisticModel:
+    p = Path(path) if path else _MODEL_PATH
+    with p.open('r') as f:
+        data = json.load(f)
+    return LogisticModel(data['intercept'], data['coefficients'])

--- a/rules.py
+++ b/rules.py
@@ -1,0 +1,15 @@
+from typing import Dict
+from features import FeatureVector
+from config import get_thresholds
+
+
+def is_candidate(fv: FeatureVector, cfg: Dict | None = None) -> bool:
+    """Check if a feature vector passes metric thresholds."""
+    cfg = cfg or get_thresholds()
+    return (
+        fv.vsr > cfg.get("vsr", 0)
+        and fv.pm > cfg.get("pm", 0)
+        and fv.obi > cfg.get("obi", 0)
+        and fv.spread < cfg.get("spread", float("inf"))
+        and fv.listing_age > cfg.get("listing_age_min", 0)
+    )

--- a/scanner.py
+++ b/scanner.py
@@ -1,0 +1,38 @@
+import asyncio
+from typing import AsyncIterator, Dict, Any
+
+from collector import MexcWSClient
+from features import FeatureEngine, FeatureVector
+from rules import is_candidate
+from model import load_model
+from config import load_config, get_thresholds, reload_config
+
+
+class Scanner:
+    """Realtime pump scanner using config-driven thresholds."""
+
+    def __init__(self, symbols: list[str]) -> None:
+        self.config = load_config()
+        self.client = MexcWSClient(symbols, self.config['mexc']['ws_url'])
+        self.engine = FeatureEngine()
+        self.model = load_model()
+
+    @property
+    def thresholds(self) -> Dict[str, Any]:
+        return get_thresholds()
+
+    async def run(self) -> AsyncIterator[tuple[FeatureVector, float]]:
+        await self.client.connect()
+        async for tick in self.client.yield_ticks():
+            fv = self.engine.update(tick, self.client)
+            if not fv.ready:
+                continue
+            if not is_candidate(fv, self.thresholds):
+                continue
+            prob = self.model.predict_proba(fv)
+            if prob >= self.config['scanner']['prob_threshold']:
+                yield fv, prob
+
+    def reload_thresholds(self) -> None:
+        reload_config()
+        self.config = load_config()


### PR DESCRIPTION
## Summary
- load thresholds from `config.yaml`
- filter `FeatureVector` instances via new `rules` module
- simple logistic model loader
- scanner wrapper with runtime `reload_thresholds`
- sample config and model weights

## Testing
- `python -m py_compile collector.py features.py config.py rules.py model.py scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_684eeefbc0c08321bce079420f6a1859