### PR TITLE
Add logging and Prometheus metrics

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -20,7 +20,8 @@ from config import load_config
 from scanner import Scanner
 from features import FeatureVector
 from storage import save_signal, save_action
-from metrics import LATENCY, SIGNALS_TOTAL, start_metrics_server
+from metrics import LATENCY, record_signal, start_metrics_server
+from logging_setup import setup_logging
 
 
 logger = logging.getLogger(__name__)
@@ -125,7 +126,7 @@ class AlertBot:
 
     async def send_alert(self, fv: FeatureVector, prob: float, start_ts: float) -> None:
         LATENCY.observe((time.time() - start_ts) * 1000)
-        SIGNALS_TOTAL.inc()
+        record_signal()
         text = (
             f"\ud83d\ude80 *{fv.symbol}*  — VSR {fv.vsr:.1f}  PM {fv.pm:.2%}  Prob {prob:.2f}\n"
             f"Time: {time.strftime('%H:%M:%S')}"
@@ -164,6 +165,7 @@ def main() -> None:
     import sys
 
     symbols = sys.argv[1:]
+    setup_logging()
     bot = AlertBot(symbols)
     asyncio.run(bot.run())
 

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,0 +1,32 @@
+import logging
+import json
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+
+class JSONFormatter(logging.Formatter):
+    """Simple JSON log formatter."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
+        log_record = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "name": record.name,
+            "msg": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def setup_logging() -> None:
+    """Configure root logger with rotation and JSON output."""
+    logs_dir = Path("data/logs")
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    handler = TimedRotatingFileHandler(
+        logs_dir / "app.log", when="D", interval=1, backupCount=7
+    )
+    handler.setFormatter(JSONFormatter())
+    console = logging.StreamHandler()
+    console.setFormatter(JSONFormatter())
+    logging.basicConfig(level=logging.INFO, handlers=[handler, console])

--- a/metrics.py
+++ b/metrics.py
@@ -1,4 +1,6 @@
-from prometheus_client import Histogram, Counter, start_http_server
+from prometheus_client import Histogram, Counter, Gauge, start_http_server
+import time
+from collections import deque
 
 LATENCY = Histogram(
     "latency_pipeline_ms",
@@ -7,6 +9,9 @@ LATENCY = Histogram(
 )
 WS_RECONNECTS = Counter("ws_reconnects_total", "Number of websocket reconnects")
 SIGNALS_TOTAL = Counter("signals_total", "Total number of signals sent")
+SIGNALS_PER_HOUR = Gauge("signals_per_hour", "Signals generated in the last hour")
+
+_signal_ts: deque[float] = deque()
 
 _started = False
 
@@ -15,3 +20,14 @@ def start_metrics_server(port: int = 8000) -> None:
     if not _started:
         start_http_server(port)
         _started = True
+
+
+def record_signal() -> None:
+    """Update counters and hourly gauge for a new signal."""
+    now = time.time()
+    _signal_ts.append(now)
+    while _signal_ts and now - _signal_ts[0] > 3600:
+        _signal_ts.popleft()
+    SIGNALS_TOTAL.inc()
+    SIGNALS_PER_HOUR.set(len(_signal_ts))
+

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1,0 +1,33 @@
+{
+  "dashboard": {
+    "title": "Pump Scanner",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "Pipeline Latency ms",
+        "targets": [
+          {"expr": "histogram_quantile(0.9, rate(latency_pipeline_ms_bucket[5m]))"}
+        ],
+        "datasource": "Prometheus"
+      },
+      {
+        "type": "graph",
+        "title": "Websocket Reconnects",
+        "targets": [
+          {"expr": "rate(ws_reconnects_total[5m])"}
+        ],
+        "datasource": "Prometheus"
+      },
+      {
+        "type": "graph",
+        "title": "Signals Per Hour",
+        "targets": [
+          {"expr": "signals_per_hour"}
+        ],
+        "datasource": "Prometheus"
+      }
+    ],
+    "schemaVersion": 37,
+    "version": 0
+  }
+}


### PR DESCRIPTION
## Summary
- configure structured JSON logs with rotation
- track signals per hour using Prometheus
- update bot to use new metrics and logging
- add sample Grafana dashboard JSON

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eff1361e08321b04f12bed576381b