### PR TITLE
Fix missing updater method

### DIFF
--- a/scanner/bot.py
+++ b/scanner/bot.py
@@ -128,8 +128,12 @@ class AlertBot:
         await self.app.initialize()
         await self.app.start()
         await self.app.updater.start_polling()
-        await self.app.updater.wait_until_closed()
-        task.cancel()
+        try:
+            await task
+        finally:
+            await self.app.updater.stop()
+            await self.app.stop()
+            await self.app.shutdown()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- fix scanner bot termination logic by removing `wait_until_closed`
- add cleanup steps for updater and application

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d25cbfd88321b30c9cea7acbd480