### PR TITLE
Add volume scout stats polling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ prometheus_client>=0.20
 python-dotenv>=1.0
 numpy>=1.25
 pyyaml>=6.0
+httpx>=0.27

--- a/scanner/volume_scout.py
+++ b/scanner/volume_scout.py
@@ -1,0 +1,83 @@
+import time
+from dataclasses import dataclass
+from collections import deque
+from typing import Deque, Dict, List, Tuple
+
+import httpx
+
+
+@dataclass
+class PairStat:
+    """Simple ticker stats for volume scout."""
+
+    symbol: str
+    quote_volume: float
+    vol_delta_5m: float
+    pm_delta_5m: float
+    hotness: float
+
+
+async def poll_stats(rest_url: str, history: Dict[str, Deque[Tuple[float, float, float]]], cfg: Dict) -> List[PairStat]:
+    """Fetch 24h stats and compute 5-minute deltas.
+
+    Parameters
+    ----------
+    rest_url : str
+        Base REST endpoint.
+    history : dict
+        Mapping ``symbol -> deque`` of ``(ts, volume, price)``.
+    cfg : dict
+        Configuration with ``min_quote_vol_usd`` and ``top_n``.
+    """
+
+    url = rest_url.rstrip("/") + "/api/v3/ticker/24hr"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+
+    now = time.time()
+    stats: List[PairStat] = []
+    for item in data:
+        symbol = item.get("symbol") or item.get("s")
+        if not symbol:
+            continue
+        vol = float(
+            item.get("quoteVolume")
+            or item.get("quote_volume")
+            or item.get("q")
+            or item.get("volume")
+            or item.get("v")
+            or 0.0
+        )
+        price = float(
+            item.get("lastPrice")
+            or item.get("last")
+            or item.get("c")
+            or item.get("close")
+            or 0.0
+        )
+
+        dq = history.setdefault(symbol, deque())
+        dq.append((now, vol, price))
+        while dq and now - dq[0][0] > 300:
+            dq.popleft()
+
+        if len(dq) >= 2:
+            vol_delta = vol - dq[0][1]
+            prev_price = dq[0][2]
+        else:
+            vol_delta = 0.0
+            prev_price = price
+
+        pm_delta = (price - prev_price) / prev_price if prev_price > 0 else 0.0
+
+        if vol < cfg.get("min_quote_vol_usd", 0):
+            continue
+
+        hotness = vol_delta * 1 + pm_delta * 50
+        stats.append(PairStat(symbol, vol, vol_delta, pm_delta, hotness))
+
+    stats.sort(key=lambda x: x.hotness, reverse=True)
+    top_n = cfg.get("top_n", len(stats))
+    return stats[:top_n]

--- a/tests/test_volume_scout.py
+++ b/tests/test_volume_scout.py
@@ -1,0 +1,64 @@
+import asyncio
+from collections import deque
+import scanner.volume_scout as scout
+
+
+class DummyResp:
+    def __init__(self, data):
+        self.data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.data
+
+
+class DummyClient:
+    def __init__(self, data):
+        self.data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, url):
+        return DummyResp(self.data)
+
+
+def test_poll_stats_rank_and_filter(monkeypatch):
+    data = [
+        {"symbol": "AAA_USDT", "quoteVolume": "1100", "lastPrice": "1.1"},
+        {"symbol": "BBB_USDT", "quoteVolume": "700", "lastPrice": "1.9"},
+        {"symbol": "CCC_USDT", "quoteVolume": "400", "lastPrice": "1.0"},
+        {"symbol": "DDD_USDT", "quoteVolume": "100", "lastPrice": "1.0"},
+    ]
+    monkeypatch.setattr(scout.httpx, "AsyncClient", lambda: DummyClient(data))
+    times = [300]
+    monkeypatch.setattr(scout.time, "time", lambda: times[0])
+    history = {
+        "AAA_USDT": deque([(0, 1000.0, 1.0)]),
+        "BBB_USDT": deque([(0, 500.0, 2.0)]),
+        "CCC_USDT": deque([(0, 50.0, 1.0)]),
+    }
+    cfg = {"min_quote_vol_usd": 300, "top_n": 2}
+    res = asyncio.run(scout.poll_stats("https://api.test", history, cfg))
+    symbols = [p.symbol for p in res]
+    assert symbols == ["CCC_USDT", "BBB_USDT"]
+    assert res[0].hotness > res[1].hotness
+
+
+def test_poll_stats_no_history(monkeypatch):
+    data = [{"symbol": "AAA_USDT", "quoteVolume": "1000", "lastPrice": "1.0"}]
+    monkeypatch.setattr(scout.httpx, "AsyncClient", lambda: DummyClient(data))
+    times = [0]
+    monkeypatch.setattr(scout.time, "time", lambda: times[0])
+    history = {}
+    cfg = {"min_quote_vol_usd": 500, "top_n": 1}
+    res = asyncio.run(scout.poll_stats("https://api.test", history, cfg))
+    ps = res[0]
+    assert ps.vol_delta_5m == 0
+    assert ps.pm_delta_5m == 0
+


### PR DESCRIPTION
## Summary
- add `volume_scout.py` module with `PairStat` and `poll_stats`
- include httpx in requirements
- unit tests for volume scout ranking and filtering

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bf188b1483219f4dd9e1f9156239