### PR TITLE
Implement subscription manager with metrics

### DIFF
--- a/scanner/__init__.py
+++ b/scanner/__init__.py
@@ -3,11 +3,13 @@
 from .scanner import Scanner
 from .collector import MexcWSClient
 from .symbols import fetch_all_pairs
+from .sub_manager import SubscriptionManager
 from config import load_config, get_thresholds, reload_config
 
 __all__ = [
     "Scanner",
     "MexcWSClient",
+    "SubscriptionManager",
     "load_config",
     "get_thresholds",
     "reload_config",

--- a/scanner/metrics.py
+++ b/scanner/metrics.py
@@ -10,6 +10,7 @@ LATENCY = Histogram(
 WS_RECONNECTS = Counter("ws_reconnects_total", "Number of websocket reconnects")
 SIGNALS_TOTAL = Counter("signals_total", "Total number of signals sent")
 SIGNALS_PER_HOUR = Gauge("signals_per_hour", "Signals generated in the last hour")
+ACTIVE_STREAMS = Gauge("active_streams", "Number of active websocket streams")
 
 _signal_ts: deque[float] = deque()
 

--- a/scanner/sub_manager.py
+++ b/scanner/sub_manager.py
@@ -1,0 +1,35 @@
+import time
+from typing import Dict, List
+
+from .collector import MexcWSClient
+from .metrics import ACTIVE_STREAMS
+
+
+class SubscriptionManager:
+    """Manage dynamic subscriptions with LRU eviction."""
+
+    def __init__(self, client: MexcWSClient, top_n: int, lru_ttl_sec: float) -> None:
+        self.client = client
+        self.top_n = top_n
+        self.lru_ttl_sec = lru_ttl_sec
+        self.active_pairs: Dict[str, float] = {}
+        ACTIVE_STREAMS.set(0)
+
+    async def ensure_subscribed(self, pairs: List[str]) -> None:
+        """Subscribe to new pairs and evict stale ones."""
+        now = time.time()
+        for p in pairs:
+            self.active_pairs[p] = now
+            if p not in self.client._symbols and hasattr(self.client, "subscribe"):
+                await self.client.subscribe(p)
+        # remove expired
+        for symbol, ts in list(self.active_pairs.items()):
+            if now - ts > self.lru_ttl_sec:
+                await self.client.unsubscribe(symbol)
+                self.active_pairs.pop(symbol, None)
+        # evict LRU if over limit
+        while len(self.active_pairs) > self.top_n:
+            oldest = min(self.active_pairs.items(), key=lambda x: x[1])[0]
+            await self.client.unsubscribe(oldest)
+            self.active_pairs.pop(oldest, None)
+        ACTIVE_STREAMS.set(len(self.active_pairs) * 2)

--- a/tests/test_sub_manager.py
+++ b/tests/test_sub_manager.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import scanner.sub_manager as sub_manager
+from scanner.sub_manager import SubscriptionManager
+
+
+class StubClient:
+    def __init__(self):
+        self._symbols = []
+        self.subscribed = []
+        self.unsubscribed = []
+
+    async def subscribe(self, sym: str) -> None:
+        self._symbols.append(sym)
+        self.subscribed.append(sym)
+
+    async def unsubscribe(self, sym: str) -> None:
+        if sym in self._symbols:
+            self._symbols.remove(sym)
+        self.unsubscribed.append(sym)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_eviction_lru(monkeypatch):
+    times = [0]
+    monkeypatch.setattr(sub_manager.time, "time", lambda: times[0])
+    client = StubClient()
+    mgr = SubscriptionManager(client, top_n=2, lru_ttl_sec=10)
+
+    run(mgr.ensure_subscribed(["AAA"]))
+    times[0] = 1
+    run(mgr.ensure_subscribed(["BBB"]))
+    times[0] = 2
+    run(mgr.ensure_subscribed(["CCC"]))
+
+    assert client.subscribed == ["AAA", "BBB", "CCC"]
+    assert client.unsubscribed == ["AAA"]
+    assert set(mgr.active_pairs) == {"BBB", "CCC"}
+
+
+def test_eviction_ttl(monkeypatch):
+    times = [0]
+    monkeypatch.setattr(sub_manager.time, "time", lambda: times[0])
+    client = StubClient()
+    mgr = SubscriptionManager(client, top_n=10, lru_ttl_sec=5)
+
+    run(mgr.ensure_subscribed(["AAA", "BBB"]))
+    times[0] = 6
+    run(mgr.ensure_subscribed([]))
+
+    assert set(client.subscribed) == {"AAA", "BBB"}
+    assert set(client.unsubscribed) == {"AAA", "BBB"}
+    assert not mgr.active_pairs


### PR DESCRIPTION
## Summary
- add `SubscriptionManager` class to manage dynamic subscriptions
- track active websocket streams via new Prometheus metric
- export manager from package
- unit tests for LRU and TTL eviction

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c02b20008321aca64631244cd691