### PR TITLE
Add dynamic subscription polling to scanner

### DIFF
--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -1,9 +1,13 @@
 from typing import AsyncIterator, Dict, Any
+import asyncio
 import logging
+import contextlib
 from .collector import MexcWSClient
 from .features import FeatureEngine, FeatureVector
 from .rules import is_candidate
 from .model import load_model
+from .volume_scout import VolumeScout
+from .sub_manager import SubscriptionManager
 import config
 
 
@@ -19,28 +23,61 @@ class Scanner:
         self.client = MexcWSClient(self.symbols, self.config['mexc']['ws_url'])
         self.engine = FeatureEngine()
         self.model = load_model()
+        scout_cfg = self.config.get('scout', {})
+        self.scout = VolumeScout(self.config['mexc'].get('rest_url', ''), scout_cfg)
+        sub_cfg = self.config.get('subscriptions', {})
+        self.sub_manager = SubscriptionManager(
+            self.client,
+            sub_cfg.get('top_n', 200),
+            sub_cfg.get('lru_ttl_sec', 900),
+        )
+        self.poll_interval = float(sub_cfg.get('poll_interval', 60))
+        self._poll_task: asyncio.Task | None = None
 
     @property
     def thresholds(self) -> Dict[str, Any]:
         return config.get_thresholds()
 
+    async def _poll_loop(self) -> None:
+        while True:
+            try:
+                stats = await self.scout.poll()
+                symbols = [s.symbol for s in stats]
+                await self.sub_manager.ensure_subscribed(symbols)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:  # pragma: no cover - runtime
+                logger.error("Volume scout error: %s", exc)
+            await asyncio.sleep(self.poll_interval)
+
     async def run(self) -> AsyncIterator[tuple[FeatureVector, float, float]]:
         logger.info("Scanner starting with %d symbols", len(self.symbols))
         await self.client.connect()
-        async for tick in self.client.yield_ticks():
-            start_ts = tick.ts
-            fv = self.engine.update(tick, self.client)
-            if not fv.ready:
-                continue
-            if not is_candidate(fv, self.thresholds):
-                continue
-            prob = self.model.predict_proba(fv)
-            if prob >= self.config['scanner']['prob_threshold']:
-                logger.info(
-                    "Signal %s prob %.2f", fv.symbol, prob
-                )
-                yield fv, prob, start_ts
+        self._poll_task = asyncio.create_task(self._poll_loop())
+        try:
+            async for tick in self.client.yield_ticks():
+                start_ts = tick.ts
+                fv = self.engine.update(tick, self.client)
+                if not fv.ready:
+                    continue
+                if not is_candidate(fv, self.thresholds):
+                    continue
+                prob = self.model.predict_proba(fv)
+                if prob >= self.config['scanner']['prob_threshold']:
+                    logger.info(
+                        "Signal %s prob %.2f", fv.symbol, prob
+                    )
+                    yield fv, prob, start_ts
+        finally:
+            if self._poll_task:
+                self._poll_task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await self._poll_task
 
     def reload_thresholds(self) -> None:
         config.reload_config()
         self.config = config.load_config()
+        scout_cfg = self.config.get('scout', {})
+        self.scout.cfg = scout_cfg
+        sub_cfg = self.config.get('subscriptions', {})
+        self.poll_interval = float(sub_cfg.get('poll_interval', 60))

--- a/scanner/volume_scout.py
+++ b/scanner/volume_scout.py
@@ -1,7 +1,7 @@
 import time
 from dataclasses import dataclass
 from collections import deque
-from typing import Deque, Dict, List, Tuple
+from typing import Deque, Dict, List, Tuple, Any
 
 import httpx
 
@@ -81,3 +81,17 @@ async def poll_stats(rest_url: str, history: Dict[str, Deque[Tuple[float, float,
     stats.sort(key=lambda x: x.hotness, reverse=True)
     top_n = cfg.get("top_n", len(stats))
     return stats[:top_n]
+
+
+class VolumeScout:
+    """Thin wrapper around :func:`poll_stats` maintaining history."""
+
+    def __init__(self, rest_url: str, cfg: Dict[str, Any]):
+        self.rest_url = rest_url
+        self.cfg = cfg
+        self.history: Dict[str, Deque[Tuple[float, float, float]]] = {}
+
+    async def poll(self) -> List[PairStat]:
+        """Return sorted pair stats."""
+        return await poll_stats(self.rest_url, self.history, self.cfg)
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,6 +16,7 @@ class FakeClient:
     async def yield_ticks(self):
         for t in self._ticks:
             _time[0] = t.ts
+            await asyncio.sleep(0)
             yield t
 
     def get_best(self, symbol):
@@ -71,3 +72,59 @@ def test_scanner_alert_generation(monkeypatch):
 
     result = asyncio.run(collect())
     assert result and result[0] > 0.6
+
+
+def test_scanner_dynamic_subscription(monkeypatch):
+    cfg = {
+        "mexc": {"ws_url": "wss://test", "rest_url": "https://api.test"},
+        "scanner": {
+            "prob_threshold": 0.0,
+            "metrics": {"vsr": 0, "pm": 0, "obi": 0, "spread": 1, "listing_age_min": 0},
+        },
+        "subscriptions": {"poll_interval": 0.01},
+    }
+    monkeypatch.setattr(config, "load_config", lambda: cfg)
+    monkeypatch.setattr(config, "get_thresholds", lambda: cfg["scanner"]["metrics"])
+    monkeypatch.setattr(scanner, "load_config", lambda: cfg)
+    monkeypatch.setattr(scanner, "get_thresholds", lambda: cfg["scanner"]["metrics"])
+
+    ticks = [Tick(symbol="AAA", kline={"c": "1", "quoteVol": "1"}, depth={}, ts=0)]
+    monkeypatch.setattr(scanner.scanner, "MexcWSClient", lambda symbols, ws_url=None: FakeClient(ticks))
+
+    class DummyScout:
+        def __init__(self, *a, **k):
+            self.polled = 0
+
+        async def poll(self):
+            self.polled += 1
+            from scanner.volume_scout import PairStat
+
+            return [PairStat("NEW", 0, 0, 0, 1.0)]
+
+    class DummyManager:
+        def __init__(self, *a, **k):
+            self.calls = []
+
+        async def ensure_subscribed(self, pairs):
+            self.calls.append(list(pairs))
+
+    monkeypatch.setattr(scanner.scanner, "VolumeScout", DummyScout)
+    monkeypatch.setattr(scanner.scanner, "SubscriptionManager", DummyManager)
+
+    class NoTrim(features.RollingWindow):
+        def _trim(self, now):
+            pass
+
+    monkeypatch.setattr(features, "RollingWindow", NoTrim)
+    global _time
+    _time = [0]
+    monkeypatch.setattr(features.time, "time", lambda: _time[0])
+
+    sc = scanner.Scanner(["AAA"])
+
+    async def collect():
+        async for _ in sc.run():
+            break
+
+    asyncio.run(collect())
+    assert sc.sub_manager.calls and sc.sub_manager.calls[0] == ["NEW"]


### PR DESCRIPTION
## Summary
- integrate dynamic volume scout subscriptions
- create `VolumeScout` helper class
- launch polling task from `Scanner.run`
- update integration tests to cover dynamic subscription behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852c684757c8321b3054723b2f63e1b