### PR TITLE
Add scout & ws config sections

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -10,6 +10,10 @@ This document explains how to configure and run the project both locally and in 
 - `scanner.stake_usdt` – amount in USDT used by the *Buy* button.
 - `scanner.prob_threshold` – minimum probability required to send an alert.
 - `scanner.metrics.*` – threshold values for VSR, PM, OBI, spread and listing age.
+- `scout.min_quote_vol_usd` – minimum 24h quote volume for a pair to be tracked.
+- `scout.top_n` – number of pairs returned by the volume scout.
+- `ws.max_streams_per_conn` – max streams per WebSocket connection.
+- `ws.max_msg_per_sec` – send rate limit per connection.
 - `telegram.token` – Telegram bot token.
 - `telegram.allowed_ids` – comma separated list of Telegram user IDs allowed to interact.
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ scanner:
     obi: ${THRESH_OBI}
     spread: ${THRESH_SPREAD}
     listing_age_min: ${THRESH_LISTING_AGE}
+scout:
+  min_quote_vol_usd: 100000
+  top_n: 200
+ws:
+  max_streams_per_conn: 30
+  max_msg_per_sec: 100
 telegram:
   token: ${TG_TOKEN}
   allowed_ids: [${ALLOWED_IDS}]

--- a/config.py
+++ b/config.py
@@ -36,6 +36,20 @@ def get_thresholds() -> Dict[str, float]:
     return _config.get('scanner', {}).get('metrics', {})
 
 
+def get_scout_cfg() -> Dict[str, Any]:
+    """Return volume scout configuration."""
+    if not _config:
+        load_config()
+    return _config.get('scout', {})
+
+
+def get_ws_cfg() -> Dict[str, Any]:
+    """Return websocket configuration."""
+    if not _config:
+        load_config()
+    return _config.get('ws', {})
+
+
 def reload_config(path: Path | str | None = None) -> Dict[str, Any]:
     """Reload configuration at runtime."""
     return load_config(path)

--- a/config.yaml
+++ b/config.yaml
@@ -16,3 +16,9 @@ scanner:
 telegram:
   token: ${TG_TOKEN}
   allowed_ids: [${ALLOWED_IDS}]
+scout:
+  min_quote_vol_usd: 100000
+  top_n: 200
+ws:
+  max_streams_per_conn: 30
+  max_msg_per_sec: 100

--- a/scanner/__init__.py
+++ b/scanner/__init__.py
@@ -4,7 +4,13 @@ from .scanner import Scanner
 from .collector import MexcWSClient
 from .symbols import fetch_all_pairs
 from .sub_manager import SubscriptionManager
-from config import load_config, get_thresholds, reload_config
+from config import (
+    load_config,
+    get_thresholds,
+    get_scout_cfg,
+    get_ws_cfg,
+    reload_config,
+)
 
 __all__ = [
     "Scanner",
@@ -12,6 +18,8 @@ __all__ = [
     "SubscriptionManager",
     "load_config",
     "get_thresholds",
+    "get_scout_cfg",
+    "get_ws_cfg",
     "reload_config",
     "fetch_all_pairs",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+import config
+
+
+def test_load_config_defaults(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(Path("config.yaml").read_text())
+
+    env = {
+        "MEXC_KEY": "k",
+        "MEXC_SECRET": "s",
+        "TG_TOKEN": "t",
+        "ALLOWED_IDS": "1",
+        "STAKE_USDT": "100",
+        "PROB_THRESHOLD": "0.5",
+        "THRESH_VSR": "1",
+        "THRESH_PM": "0.1",
+        "THRESH_OBI": "0.2",
+        "THRESH_SPREAD": "0.01",
+        "THRESH_LISTING_AGE": "100",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    cfg = config.load_config(cfg_path)
+    assert cfg["scout"]["min_quote_vol_usd"] == 100000
+    assert cfg["scout"]["top_n"] == 200
+    assert cfg["ws"]["max_streams_per_conn"] == 30
+    assert cfg["ws"]["max_msg_per_sec"] == 100
+    assert cfg["scanner"]["prob_threshold"] == float(env["PROB_THRESHOLD"])


### PR DESCRIPTION
## Summary
- extend default `config.yaml` with `scout` and `ws` sections
- expose `get_scout_cfg` and `get_ws_cfg` in `config.py` and package init
- document new configuration options in README and DEPLOYMENT guide
- cover config loading with tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c80842048321a11851f1cc539141