### PR TITLE
Add httpx socks extra

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -64,7 +64,8 @@ The Grafana dashboard JSON remains in `monitoring/` and works as before.
 
 ## Running with Docker
 
-Build and start via `docker-compose`:
+Build and start via `docker-compose` (rebuild if dependencies changed):
+Dependencies like `httpx[socks]` are installed during the build stage.
 
 ```bash
 docker-compose up -d --build

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ services:
 git clone https://github.com/you/mexc-pump-scanner.git || true
 cd mexc-pump-scanner
 sudo docker compose up -d --build
+# rebuild to install new dependencies like httpx[socks]
 ```
 
 Скрипт ставит Docker при необходимости и может создать unit `systemd`, чтобы

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv>=1.0
 numpy>=1.25
 pyyaml>=6.0
 httpx>=0.27
+httpx[socks]>=0.27


### PR DESCRIPTION
## Summary
- install `httpx[socks]` to enable SOCKS proxies
- mention rebuilding the Docker image
- document the new dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852cb1b4f9883218efb0b5b11c0d675